### PR TITLE
fix: allow finalizer to cleanup to continue on error (fixes #173)

### DIFF
--- a/src/FeatureFlagSetLDController.js
+++ b/src/FeatureFlagSetLDController.js
@@ -217,11 +217,8 @@ module.exports = class FeatureFlagSetLDController extends BaseController {
     for (let i = 0; i < sdkKeys.length; i++) {
       const sdkKey = sdkKeys[i];
       const instanceUids = Object.keys(objectPath.get(clients, [sdkKey, 'instances']));
-      for (let j = 0; j < instanceUids.length; j++) {
-        const uid = instanceUids[j];
-        if (uid === instanceUid) {
-          return sdkKey;
-        }
+      if (instanceUids.indexOf(instanceUid) !== -1) {
+        return sdkKey;
       }
     }
   }

--- a/src/FeatureFlagSetLDController.js
+++ b/src/FeatureFlagSetLDController.js
@@ -248,7 +248,6 @@ module.exports = class FeatureFlagSetLDController extends BaseController {
       objectPath.del(clients, [sdkkey]);
       this.log.debug(`Client closed successfully ${sdkkey}`);
     }
-
   }
 
 };

--- a/src/FeatureFlagSetLDController.js
+++ b/src/FeatureFlagSetLDController.js
@@ -243,7 +243,7 @@ module.exports = class FeatureFlagSetLDController extends BaseController {
 
     if (Object.keys(objectPath.get(clients, [sdkkey, 'instances'], {})).length == 0) {
       this.log.debug(`Closing client ${sdkkey}`);
-      let client = objectPath.get(clients, [sdkkey, 'client'], { close: () => { } });
+      const client = objectPath.get(clients, [sdkkey, 'client'], { close: () => { } });
       client.close();
       objectPath.del(clients, [sdkkey]);
       this.log.debug(`Client closed successfully ${sdkkey}`);

--- a/src/FeatureFlagSetLDController.js
+++ b/src/FeatureFlagSetLDController.js
@@ -235,7 +235,7 @@ module.exports = class FeatureFlagSetLDController extends BaseController {
       this.log.warn(`Failed to get sdk key from kube-api during ${this.name}'s finalizer cleanup. resorting to table lookup.`, e);
       sdkkey = this._getSdkKeyFromDict(instanceUid);
       if (sdkkey === undefined) {
-        this.log.debug('No sdkkey found in table lookup, skipping cleanup since sdkkey isnt associated with a client.');
+        this.log.debug('No sdkkey found in table lookup, skipping cleanup since sdkkey is not associated with a client.');
         return;
       }
     }


### PR DESCRIPTION
currently finalizer cleanup will never continue when this._getSdkKey errors. In this case, a keyref pointing to a key/secret that doesnt exist will cause finalizer cleanup to fail forever. I considered narrowing the scope of error that we allow to be skipped, but for now am just leaving it wide open until more time is availbe to decide on a better subset of error codes that we should allow skipping on. I believe the only side effects of this, is after a while, if there are a lot of keys that dont get cleaned up, we end up leaving open a lot of open conections to LD. In most cases this shouldnt be an issue since it is rare to use a bunch of different sdk keys, and even rarer to try to clean them all up and have issues before the pod gets restarted and all connections are closed anyways.
